### PR TITLE
Simple plugin for pycbc

### DIFF
--- a/esigmapy/__init__.py
+++ b/esigmapy/__init__.py
@@ -23,7 +23,12 @@ _params = inspect.signature(get_imr_esigma_waveform).parameters.keys()
 def pycbc_esigma(**params):
     pt = {p: params[p] for p in _params if p in params}
     pt['f_ref'] = None
-    return get_imr_esigma_waveform(pt.pop('mass1'), pt.pop('mass2'),
+
+    gen_wav = get_imr_esigma_waveform
+    if 'skip_merger' in params:
+        gen_wav = get_inspiral_esigma_waveform
+
+    return gen_wav(pt.pop('mass1'), pt.pop('mass2'),
                             pt.pop('f_lower'), pt.pop('delta_t'),
                             **pt, modes_to_use=[(2,2), (2,-2)])
 

--- a/esigmapy/__init__.py
+++ b/esigmapy/__init__.py
@@ -17,4 +17,14 @@ def get_version_information():
         print("No version information file '.version' found")
 
 
+# pycbc wrapper
+import inspect
+_params = inspect.signature(get_imr_esigma_waveform).parameters.keys()
+def pycbc_esigma(**params):
+    pt = {p: params[p] for p in _params if p in params}
+    pt['f_ref'] = None
+    return get_imr_esigma_waveform(pt.pop('mass1'), pt.pop('mass2'),
+                            pt.pop('f_lower'), pt.pop('delta_t'),
+                            **pt, modes_to_use=[(2,2), (2,-2)])
+
 __version__ = get_version_information()

--- a/esigmapy/__init__.py
+++ b/esigmapy/__init__.py
@@ -23,17 +23,19 @@ _params = inspect.signature(get_imr_esigma_waveform).parameters.keys()
 def pycbc_esigma(**params):
     from pycbc.waveform.waveform import parse_mode_array
 
+    # Pass all parameters the model suppports
     pt = {p: params[p] for p in _params if p in params}
-    pt['f_ref'] = None
+    pt['f_ref'] = pt['f_lower'] if pt['f_ref'] == 0 else pt['f_ref']
 
     gen_wav = get_imr_esigma_waveform
     if 'skip_merger' in params:
         gen_wav = get_inspiral_esigma_waveform
 
     modes = params.pop('mode_array', [(2,2), (2,-2)])
+    modes = parse_mode_array({'mode_array':modes})['mode_array']
 
     return gen_wav(pt.pop('mass1'), pt.pop('mass2'),
                    pt.pop('f_lower'), pt.pop('delta_t'),
-                   **pt, modes_to_use=parse_mode_array(modes))
+                   **pt, modes_to_use=modes)
 
 __version__ = get_version_information()

--- a/esigmapy/__init__.py
+++ b/esigmapy/__init__.py
@@ -21,6 +21,8 @@ def get_version_information():
 import inspect
 _params = inspect.signature(get_imr_esigma_waveform).parameters.keys()
 def pycbc_esigma(**params):
+    from pycbc.waveform.waveform import parse_mode_array
+
     pt = {p: params[p] for p in _params if p in params}
     pt['f_ref'] = None
 
@@ -28,8 +30,10 @@ def pycbc_esigma(**params):
     if 'skip_merger' in params:
         gen_wav = get_inspiral_esigma_waveform
 
+    modes = params.pop('mode_array', [(2,2), (2,-2)])
+
     return gen_wav(pt.pop('mass1'), pt.pop('mass2'),
-                            pt.pop('f_lower'), pt.pop('delta_t'),
-                            **pt, modes_to_use=[(2,2), (2,-2)])
+                   pt.pop('f_lower'), pt.pop('delta_t'),
+                   **pt, modes_to_use=parse_mode_array(modes))
 
 __version__ = get_version_information()

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ if __name__ == "__main__":
         author_email="prayush.kumar@gmail.com",
         packages=find_packages(),
         package_dir={NAME: NAME},
+        entry_points = {"pycbc.waveform.td":"esigma = esigmapy:pycbc_esigma"},
         package_data={},
         install_requires=[
             # 'lalsuite>=6.63',


### PR DESCRIPTION
This is an alternative approach than suggested in #1 to allow pycbc to access this model. It tries to just do the minimal translation to the native interface. 


Example use after installing

```
from pycbc.waveform import get_td_waveform

hp, hc = get_td_waveform(approximant="esigma", mass1=10, mass2=50, f_lower=30., inclination=1.3,
                         eccentricity=0.3, delta_t=1.0/2048, mode_array="22")


hp2, hc2 = get_td_waveform(approximant="esigma", mass1=10, mass2=50, f_lower=30., inclination=1.3,
                         eccentricity=0.3, delta_t=1.0/2048, mode_array="22 33")

hp.plot()
hp2.plot()
```
<img width="546" height="428" alt="download" src="https://github.com/user-attachments/assets/5a1feed0-baa2-4651-b2ad-771136e62020" />


