### PR TITLE
Optimize with numba, add unit tests for mode blending

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203, E741, W291, W503, E501, E402, E712, E722, F541
+exclude = build
+per-file-ignores =
+    **/__init__.py: F401, F403

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install lalsuite pycbc pytest black numba
+          pip install -e .
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/esigmapy/blend.py
+++ b/esigmapy/blend.py
@@ -5,7 +5,26 @@ specifically to be used for gravitational waveform hybridisation, fine-tuned for
 """
 
 import numpy as np
-from scipy.integrate import cumulative_trapezoid
+from numba import njit
+
+
+@njit
+def _find_first_value_location_in_series_numba(frq_timeseries, frq_desired):
+    n = len(frq_timeseries)
+    final_idx = -1
+    for idx in range(n - 1):
+        if (
+            frq_timeseries[idx] <= frq_desired
+            and frq_timeseries[idx + 1] >= frq_desired
+        ):
+            fr1 = frq_timeseries[idx]
+            fr2 = frq_timeseries[idx + 1]
+            if abs(frq_desired - fr1) <= abs(frq_desired - fr2):
+                final_idx = idx
+            else:
+                final_idx = idx + 1
+            break
+    return final_idx
 
 
 # Akash: Can use @njit here, but numba is not a dependency of default ESIGMAPy currently
@@ -16,19 +35,29 @@ def find_first_value_location_in_series(frq_timeseries, frq_desired):
     if frq_desired > np.max(frq_timeseries):
         raise Exception("Desired frequency out of bounds, higher than max frequency")
 
-    """ 
-    We traverse the array to find the location where the i_th value is less than
-    the desired value while the i+1_th value is more, hence locating the desired 
-    value somewhere between those two points. We then choose the value closer to 
-    the value desired (among i and i+1) and call it the location of the desired value. 
-    """
-    for idx in range(len(frq_timeseries) - 1):
-        if frq_timeseries[idx] <= frq_desired <= frq_timeseries[idx + 1]:
-            fr1 = frq_timeseries[idx]
-            fr2 = frq_timeseries[idx + 1]
-            # If equidistant, <= ensures we select the earlier index (idx)
-            return idx if abs(frq_desired - fr1) <= abs(frq_desired - fr2) else idx + 1
-    raise ValueError("frq_desired not found in frq_timeseries")
+    idx = _find_first_value_location_in_series_numba(
+        np.asarray(frq_timeseries, dtype=np.float64),
+        float(frq_desired),
+    )
+    if idx == -1:
+        raise ValueError("Desired frequency bracket not found in timeseries")
+    return idx
+
+
+@njit
+def _find_last_value_location_in_series_numba(frq_timeseries, frq_desired):
+    n = len(frq_timeseries)
+    final_idx = n - 1
+    for idx in range(n - 1):
+        val1 = frq_timeseries[n - 1 - idx]
+        val2 = frq_timeseries[n - 2 - idx]
+        if val1 >= frq_desired and val2 <= frq_desired:
+            if abs(frq_desired - val1) <= abs(frq_desired - val2):
+                final_idx = idx
+            else:
+                final_idx = idx + 1
+            break
+    return n - 1 - final_idx
 
 
 # Akash: Can use @njit here, but numba is not a dependency of default ESIGMAPy currently
@@ -43,34 +72,13 @@ def find_last_value_location_in_series(frq_timeseries, frq_desired):
             f"""Desired value {frq_desired} out of bounds, higher than max value {np.max(frq_timeseries)}"""
         )
 
-    """ 
-    We reverse the array and traverse it to find the location where the i_th value is more than
-    the desired value while the i+1_th value is less, hence locating the desired value somewhere
-    between those two points. We then choose the value closer to the value desired (among i and i+1) 
-    and call it the location of the desired value. 
-    """
-    reversed_freq_timeseries = frq_timeseries[::-1]
-    final_idx = None
-
-    for idx in range(len(reversed_freq_timeseries) - 1):
-        # This assumes that the frequency is monotonically increasing with time,
-        # which is true only for orbit-averaged frequency for eccentric waveforms
-        if (
-            reversed_freq_timeseries[idx]
-            >= frq_desired
-            >= reversed_freq_timeseries[idx + 1]
-        ):
-            fr1 = reversed_freq_timeseries[idx]
-            fr2 = reversed_freq_timeseries[idx + 1]
-            final_idx = (
-                idx if abs(frq_desired - fr1) <= abs(frq_desired - fr2) else idx + 1
-            )
-            break
-    if final_idx is None:
-        raise ValueError("frq_desired not found in frq_timeseries")
-    return len(frq_timeseries) - 1 - final_idx
+    return _find_last_value_location_in_series_numba(
+        np.asarray(frq_timeseries, dtype=np.float64),
+        float(frq_desired),
+    )
 
 
+@njit
 def blend_series(x1, x2, t1_index_insp, t2_index_insp, t1_index_mr, t2_index_mr):
     """
     Function to blend two series x1 and x2 over the window defined by t1_index_insp, t2_index_insp for x1 and t1_index_mr, t2_index_mr for x2.
@@ -93,17 +101,15 @@ def blend_series(x1, x2, t1_index_insp, t2_index_insp, t1_index_mr, t2_index_mr)
     if insp_index_range != mr_index_range:
         raise ValueError("Inconsistent indices passed to blending function")
 
-    # blending fn is an array
-    blfn_var = np.arange(
-        t1_index_insp, t2_index_insp + 1
-    )  # +1 since the window is inclusive of t2_index_insp
-    tau = np.square(
-        (np.sin((np.pi / 2) * (blfn_var - t1_index_insp) / insp_index_range))
-    )
+    n_points = insp_index_range + 1
+    x_hyb = np.empty(n_points, dtype=x1.dtype)
 
-    x_hyb = (1 - tau) * x1[t1_index_insp : t2_index_insp + 1] + tau * x2[
-        t1_index_mr : t2_index_mr + 1
-    ]
+    for i in range(n_points):
+        tau_val = np.sin((np.pi / 2) * i / insp_index_range) ** 2
+        x_hyb[i] = (1.0 - tau_val) * x1[t1_index_insp + i] + tau_val * x2[
+            t1_index_mr + i
+        ]
+
     return x_hyb
 
 
@@ -112,14 +118,37 @@ def compute_amplitude(waveform):
     return amplitude
 
 
+@njit
 def compute_phase(waveform):
-    phase = np.unwrap(-np.angle(waveform))
-    return phase
+    angle = -np.angle(waveform)
+    n = len(angle)
+    unwrapped = np.empty(n, dtype=np.float64)
+    if n == 0:
+        return unwrapped
+    unwrapped[0] = angle[0]
+    for i in range(1, n):
+        diff = angle[i] - angle[i - 1]
+        diff = (diff + np.pi) % (2 * np.pi) - np.pi
+        unwrapped[i] = unwrapped[i - 1] + diff
+    return unwrapped
 
 
+@njit
 def compute_frequency(phase, delta_t):
-    frequency = np.gradient(phase, delta_t) / (2 * np.pi)
-    return frequency
+    n = len(phase)
+    freq = np.empty(n, dtype=np.float64)
+    if n == 0:
+        return freq
+    if n == 1:
+        freq[0] = 0.0
+        return freq
+    factor = 1.0 / (2 * np.pi * delta_t)
+    freq[0] = (phase[1] - phase[0]) * factor
+    freq[n - 1] = (phase[n - 1] - phase[n - 2]) * factor
+    factor2 = 1.0 / (4 * np.pi * delta_t)
+    for i in range(1, n - 1):
+        freq[i] = (phase[i + 1] - phase[i - 1]) * factor2
+    return freq
 
 
 def blend_modes(
@@ -348,17 +377,6 @@ Try moving frq_attach to a lower value."""
 
     amp_insp_window = {}
     amp_mr_window = {}
-
-    for el_i, em_i in modes_to_blend:
-        amp_insp_window[(el_i, em_i)] = compute_amplitude(
-            inspiral_modes[(el_i, em_i)][t1_index_insp : t2_index_insp + 1]
-        )
-        amp_mr_window[(el_i, em_i)] = compute_amplitude(
-            merger_ringdown_modes[(el_i, em_i)][t1_index_mr : t2_index_mr + 1]
-        )
-
-    """ Blending the mode amplitudes and frequencies using the blending function """
-
     amp_hyb_window = {}
     frq_hyb_window = {}
     phase_hyb_window = {}
@@ -368,48 +386,43 @@ Try moving frq_attach to a lower value."""
     len_mr_window = t2_index_mr - t1_index_mr
 
     for el, em in modes_to_blend:
-        amp_hyb_window[(el, em)] = blend_series(
-            amp_insp_window[(el, em)],  # This should have length len_insp_window + 1
-            amp_mr_window[(el, em)],  # This should have length len_mr_window + 1
+        amp_insp_w = compute_amplitude(
+            inspiral_modes[(el, em)][t1_index_insp : t2_index_insp + 1]
+        )
+        amp_mr_w = compute_amplitude(
+            merger_ringdown_modes[(el, em)][t1_index_mr : t2_index_mr + 1]
+        )
+        amp_insp_window[(el, em)] = amp_insp_w
+        amp_mr_window[(el, em)] = amp_mr_w
+        amp_h = blend_series(amp_insp_w, amp_mr_w, 0, len_insp_window, 0, len_mr_window)
+        amp_hyb_window[(el, em)] = amp_h
+
+        frq_h = blend_series(
+            frq_insp_window[(el, em)],
+            frq_mr_window[(el, em)],
             0,
             len_insp_window,
             0,
             len_mr_window,
         )
-        frq_hyb_window[(el, em)] = blend_series(
-            frq_insp_window[(el, em)],  # This should have length len_insp_window + 1
-            frq_mr_window[(el, em)],  # This should have length len_mr_window + 1
-            0,
-            len_insp_window,
-            0,
-            len_mr_window,
-        )
-        """ Integrating frq_hyb to obtain phase_hyb. """
+        frq_hyb_window[(el, em)] = frq_h
 
-        phase_hyb_window[(el, em)] = (2 * np.pi) * cumulative_trapezoid(
-            frq_hyb_window[(el, em)], dx=delta_t, initial=0
-        )
+        # Trapezoidal integration: phase = 2π ∫ f dt
+        phase_h = np.empty(len(frq_h))
+        phase_h[0] = 0.0
+        phase_h[1:] = np.cumsum(0.5 * (frq_h[:-1] + frq_h[1:]) * delta_t)
+        phase_h *= 2 * np.pi
 
-    """ Right now the phase is integrated only inside the hybridization window, 
-    need to add constants to preserve phase continuity and compile full IMR modes. """
-
-    for el, em in modes_to_blend:
         inspiral_angle_at_window_start = -np.angle(
             inspiral_modes[(el, em)][t1_index_insp]
         )
         mr_angle_at_window_end = -np.angle(merger_ringdown_modes[(el, em)][t2_index_mr])
 
         if blend_aligning_merger_to_inspiral:
-            # Because phase_hyb_window[(el, em)] starts from 0 phase
-            # this will ensure that phase_hyb_window starts from
-            # inspiral_angle_at_window_start
-            phase_hyb_window[(el, em)] += inspiral_angle_at_window_start
-            mode_within_window = amp_hyb_window[(el, em)] * np.exp(
-                -1j * phase_hyb_window[(el, em)]
-            )
-            mr_phasor_shift = np.exp(
-                -1j * (phase_hyb_window[(el, em)][-1] - mr_angle_at_window_end)
-            )
+            phase_h += inspiral_angle_at_window_start
+            phase_hyb_window[(el, em)] = phase_h
+            mode_within_window = amp_h * np.exp(-1j * phase_h)
+            mr_phasor_shift = np.exp(-1j * (phase_h[-1] - mr_angle_at_window_end))
             hybrid_modes[(el, em)] = np.concatenate(
                 (
                     inspiral_modes[(el, em)][:t1_index_insp],
@@ -419,17 +432,11 @@ Try moving frq_attach to a lower value."""
                 )
             )
         else:
-            # Because phase_hyb_window[(el, em)] starts from 0 phase
-            # this will ensure that phase_hyb_window ends at
-            # mr_angle_at_window_end
-            phase_hyb_window[(el, em)] += (
-                mr_angle_at_window_end - phase_hyb_window[(el, em)][-1]
-            )
-            mode_within_window = amp_hyb_window[(el, em)] * np.exp(
-                -1j * phase_hyb_window[(el, em)]
-            )
+            phase_h += mr_angle_at_window_end - phase_h[-1]
+            phase_hyb_window[(el, em)] = phase_h
+            mode_within_window = amp_h * np.exp(-1j * phase_h)
             inspiral_phasor_shift = np.exp(
-                -1j * (phase_hyb_window[(el, em)][0] - inspiral_angle_at_window_start)
+                -1j * (phase_h[0] - inspiral_angle_at_window_start)
             )
             hybrid_modes[(el, em)] = np.concatenate(
                 (

--- a/esigmapy/blend.py
+++ b/esigmapy/blend.py
@@ -35,6 +35,13 @@ def find_first_value_location_in_series(frq_timeseries, frq_desired):
     if frq_desired > np.max(frq_timeseries):
         raise Exception("Desired frequency out of bounds, higher than max frequency")
 
+    """
+    We traverse the array to find the location where the i_th value is less than
+    the desired value while the i+1_th value is more, hence locating the desired
+    value somewhere between those two points. We then choose the value closer to
+    the value desired (among i and i+1) and call it the location of the desired
+    value.
+    """
     idx = _find_first_value_location_in_series_numba(
         np.asarray(frq_timeseries, dtype=np.float64),
         float(frq_desired),
@@ -47,20 +54,16 @@ def find_first_value_location_in_series(frq_timeseries, frq_desired):
 @njit
 def _find_last_value_location_in_series_numba(frq_timeseries, frq_desired):
     n = len(frq_timeseries)
-    final_idx = n - 1
-    for idx in range(n - 1):
-        val1 = frq_timeseries[n - 1 - idx]
-        val2 = frq_timeseries[n - 2 - idx]
+    for off in range(n - 1):
+        i1 = n - 1 - off
+        i2 = n - 2 - off
+        val1 = frq_timeseries[i1]
+        val2 = frq_timeseries[i2]
         if val1 >= frq_desired and val2 <= frq_desired:
-            if abs(frq_desired - val1) <= abs(frq_desired - val2):
-                final_idx = idx
-            else:
-                final_idx = idx + 1
-            break
-    return n - 1 - final_idx
+            return i1 if abs(frq_desired - val1) <= abs(frq_desired - val2) else i2
+    return -1
 
 
-# Akash: Can use @njit here, but numba is not a dependency of default ESIGMAPy currently
 def find_last_value_location_in_series(frq_timeseries, frq_desired):
     if frq_desired < np.min(frq_timeseries):
         raise Exception(
@@ -72,10 +75,20 @@ def find_last_value_location_in_series(frq_timeseries, frq_desired):
             f"""Desired value {frq_desired} out of bounds, higher than max value {np.max(frq_timeseries)}"""
         )
 
-    return _find_last_value_location_in_series_numba(
+    """
+    We traverse the array in reverse to find the location where the i_th value
+    is more than the desired value while the i+1_th value is less, hence locating
+    the desired value somewhere between those two points. We then choose the
+    value closer to the value desired (among i and i+1) and call it the location
+    of the desired value.
+    """
+    idx = _find_last_value_location_in_series_numba(
         np.asarray(frq_timeseries, dtype=np.float64),
         float(frq_desired),
     )
+    if idx < 0:
+        raise ValueError("Desired frequency bracket not found in timeseries")
+    return idx
 
 
 @njit

--- a/esigmapy/generator.py
+++ b/esigmapy/generator.py
@@ -10,6 +10,7 @@ import esigmapy
 import lal
 import lalsimulation as ls
 import pycbc.types as pt
+from numba import njit
 from .utils import f_ISCO_spin
 from .condition import apply_taper_both_pols
 from .mr_generator import check_available_mr_approximants, get_mr_modes
@@ -464,6 +465,25 @@ def get_inspiral_esigma_waveform(
     return t, hp, hc
 
 
+@njit
+def _get_window_start_numba(freq_, delta_t_, delta_phi_, direction_is_backward):
+    n = len(freq_)
+    abs_delta_phi = abs(delta_phi_)
+    if direction_is_backward:
+        val = 0.0
+        for idx in range(n - 2, 0, -1):
+            val += 0.5 * (freq_[idx] + freq_[idx + 1]) * delta_t_
+            if abs(val) >= abs_delta_phi:
+                return idx
+    else:
+        val = 0.0
+        for idx in range(1, n):
+            val += 0.5 * (freq_[idx - 1] + freq_[idx]) * delta_t_
+            if abs(val) >= abs_delta_phi:
+                return idx
+    return -1
+
+
 def _get_window_start(freq_, delta_t_, delta_phi_, direction="forward"):
     """Integrates frequency backward/forward from the start/end until
     `delta_phi_` radians of orbital phase has elapsed.
@@ -478,20 +498,14 @@ def _get_window_start(freq_, delta_t_, delta_phi_, direction="forward"):
     Returns:
         int: Index in frequency array where `delta_phi` is reached
     """
-    from scipy import integrate
-
-    if direction == "backward":
-        for idx in range(len(freq_) - 2, 0, -1):
-            # this could be optimized to not repeat integration
-            if abs(integrate.trapezoid(freq_[idx:], dx=delta_t_)) >= abs(delta_phi_):
-                return idx
-    elif direction == "forward":
-        for idx in range(1, len(freq_)):
-            # this could be optimized to not repeat integration
-            if abs(integrate.trapezoid(freq_[: idx + 1], dx=delta_t_)) >= abs(
-                delta_phi_
-            ):
-                return idx
+    direction_is_backward = direction == "backward"
+    idx = _get_window_start_numba(
+        np.asarray(freq_, dtype=np.float64),
+        float(delta_t_),
+        float(delta_phi_),
+        direction_is_backward,
+    )
+    return idx if idx != -1 else None
 
 
 def _get_transition_frequency_window(
@@ -547,17 +561,12 @@ def _get_transition_frequency_window(
             in the orbital frequency array of length {len(orbital_freq)}""")
 
     if blend_using_avg_orbital_frequency:
-        # We integrate `orbital_freq` to obtain `orbital_phase`
-        from scipy import integrate
-
-        orbital_phase = integrate.cumulative_trapezoid(
-            orbital_freq, dx=delta_t, initial=0
+        # Trapezoidal integration of orbital_freq to get orbital_phase
+        orbital_phase = np.empty(len(orbital_freq))
+        orbital_phase[0] = 0.0
+        orbital_phase[1:] = np.cumsum(
+            0.5 * (orbital_freq[:-1] + orbital_freq[1:]) * delta_t
         )
-        if len(orbital_phase) != len(orbital_freq):
-            raise RuntimeError(
-                f"""Something went wrong while integrating orbital frequency.
-They have different lengths: {len(orbital_freq)} and {len(orbital_phase)}."""
-            )
 
     if keep_f_mr_transition_at_center:
         # Orbital cycle based hybridization that keeps f_mr_transition at

--- a/esigmapy/utils.py
+++ b/esigmapy/utils.py
@@ -2,8 +2,15 @@
 #
 from __future__ import absolute_import, print_function
 
+import functools
 import lal
 import numpy as np
+from numba import njit
+
+
+@functools.lru_cache(maxsize=512)
+def _ylm(inclination, coa_phase, el, em):
+    return lal.SpinWeightedSphericalHarmonic(inclination, coa_phase, -2, el, em)
 
 
 def f22_from_x(x, M):
@@ -114,6 +121,26 @@ def f_ISCO_spin(mass1, mass2, spin1z, spin2z):
     return 1 / 2 * fre
 
 
+@njit
+def _get_peak_freqs_numba(fvals, sample_times):
+    n = len(fvals)
+    count = 0
+    for idx in range(1, n - 1):
+        if fvals[idx - 1] < fvals[idx] and fvals[idx + 1] < fvals[idx]:
+            count += 1
+
+    peaks = np.empty(count)
+    peak_times = np.empty(count)
+    curr = 0
+    for idx in range(1, n - 1):
+        if fvals[idx - 1] < fvals[idx] and fvals[idx + 1] < fvals[idx]:
+            peaks[curr] = fvals[idx]
+            peak_times[curr] = sample_times[idx]
+            curr += 1
+
+    return peak_times, peaks
+
+
 def get_peak_freqs(freq):
     """
     Inputs
@@ -125,18 +152,9 @@ def get_peak_freqs(freq):
     peak_times: Times at which local maxima of frequency are attained
     peak_freqs: Frequency at these times
     """
-    peaks, peak_times = [], []
-    fvals = freq.data
-
-    for idx, finst in enumerate(fvals):
-        if idx == 0 or idx == len(fvals) - 1:
-            continue
-
-        if ((fvals[idx - 1]) < (finst)) and ((fvals[idx + 1]) < (finst)):
-            peaks.append(finst)
-            peak_times.append(freq.sample_times[idx])
-
-    return np.array(peak_times), np.array(peaks)
+    fvals = np.asarray(freq.data, dtype=np.float64)
+    sample_times = np.asarray(freq.sample_times, dtype=np.float64)
+    return _get_peak_freqs_numba(fvals, sample_times)
 
 
 def get_polarizations_from_multipoles(
@@ -170,7 +188,7 @@ def get_polarizations_from_multipoles(
         hc = waveform_multipoles[available_modes[0]].real() * 0
 
     for el, em in waveform_multipoles:
-        ylm = lal.SpinWeightedSphericalHarmonic(inclination, coa_phase, -2, el, em)
+        ylm = _ylm(inclination, coa_phase, el, em)
         glm = waveform_multipoles[(el, em)] * ylm
         if verbose > 4:
             print(f"Adding mode {el}, {em} with ylm = {ylm}", flush=True)

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ if __name__ == "__main__":
             # 'lalsuite>=6.63',
             "lscsoft_glue>=2.0.0",
             "matplotlib>=2.1",
+            "numba",
             "numpy",
             "pycbc",
             "scipy>=1.2.3",
@@ -122,7 +123,6 @@ if __name__ == "__main__":
         extras_require={
             "surrogate": [
                 "tpi-splines",
-                "numba",
             ],
             "pyseobnr": ["pyseobnr"],
             "dev": [
@@ -130,9 +130,10 @@ if __name__ == "__main__":
                 "pytest",
             ],
             "all": [
-                "tpi-splines",
-                "numba",
+                "black==26.5.1",
                 "pyseobnr",
+                "pytest",
+                "tpi-splines",
             ],
         },
         scripts=[],

--- a/tests/test_blend.py
+++ b/tests/test_blend.py
@@ -342,3 +342,237 @@ class TestBlendModesValidation:
                 modes_to_blend=[(2, 2), (3, 3)],
                 include_conjugate_modes=False,
             )
+
+
+# ---------------------------------------------------------------------------
+# blend_modes — output correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def blend_setup():
+    """Synthetic linear-chirp inspiral + MR modes with a known blending window.
+
+    (2,2) inspiral: 40→160 Hz GW over 500 samples  (orbital: 20→80 Hz)
+    (2,2) MR      : 60→300 Hz GW over 200 samples
+    Attach at 120 Hz ± 10 Hz, using avg orbital frequency.
+    """
+    dt = 1.0 / 4096
+    N_insp, N_mr = 500, 200
+
+    def chirp(N, f0, f1):
+        t = np.arange(N) * dt
+        T = (N - 1) * dt
+        phi = 2 * np.pi * (f0 * t + 0.5 * (f1 - f0) / T * t**2)
+        return np.exp(-1j * phi)
+
+    insp_22 = chirp(N_insp, 40, 160)
+    mr_22 = chirp(N_mr, 60, 300)
+    return {
+        "inspiral_modes": {(2, 2): insp_22, (2, -2): np.conj(insp_22)},
+        "mr_modes": {(2, 2): mr_22, (2, -2): np.conj(mr_22)},
+        "orbital_freq": np.linspace(20, 80, N_insp),
+        "frq_attach": 120.0,
+        "frq_width": 20.0,
+        "dt": dt,
+    }
+
+
+def _run_blend(setup, **overrides):
+    kwargs = dict(
+        modes_to_blend=[(2, 2), (2, -2)],
+        mode_to_align_by=(2, 2),
+        blend_using_avg_orbital_frequency=True,
+        blend_aligning_merger_to_inspiral=True,
+        include_conjugate_modes=False,
+        delta_t=setup["dt"],
+        frq_width=setup["frq_width"],
+    )
+    kwargs.update(overrides)
+    return blend_modes(
+        setup["inspiral_modes"],
+        setup["mr_modes"],
+        setup["orbital_freq"],
+        setup["frq_attach"],
+        **kwargs,
+    )
+
+
+class TestBlendModesOutput:
+    """Correctness tests for blend_modes output values.
+
+    Return tuple layout:
+        [0] hybrid_modes dict
+        [1] t1_index_insp,  [2] t1_index_mr
+        [3] t2_index_insp,  [4] t2_index_mr
+        [5] frq_insp_window, [6] frq_hyb_window, [7] frq_mr_window
+        [8] amp_insp_window, [9] amp_hyb_window,  [10] amp_mr_window
+    """
+
+    def test_return_tuple_length(self, blend_setup):
+        assert len(_run_blend(blend_setup)) == 11
+
+    def test_hybrid_keys_match_modes_to_blend(self, blend_setup):
+        result = _run_blend(blend_setup)
+        assert set(result[0].keys()) == {(2, 2), (2, -2)}
+
+    def test_hybrid_mode_is_ndarray(self, blend_setup):
+        result = _run_blend(blend_setup)
+        assert isinstance(result[0][(2, 2)], np.ndarray)
+
+    # ── inspiral head / MR tail preservation ─────────────────────────────
+
+    def test_inspiral_head_unchanged_when_aligning_mr(self, blend_setup):
+        """Before t1_index_insp the hybrid must equal the inspiral exactly."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=True)
+        hybrid = result[0][(2, 2)]
+        t1_i = result[1]
+        np.testing.assert_array_equal(
+            hybrid[:t1_i], blend_setup["inspiral_modes"][(2, 2)][:t1_i]
+        )
+
+    def test_mr_tail_unchanged_when_aligning_inspiral(self, blend_setup):
+        """After t2_index_mr the MR tail must be unchanged (phase shift lands on inspiral head)."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=False)
+        hybrid = result[0][(2, 2)]
+        t2_mr = result[4]
+        mr = blend_setup["mr_modes"][(2, 2)]
+        np.testing.assert_array_equal(hybrid[-(len(mr) - t2_mr - 1) :], mr[t2_mr + 1 :])
+
+    # ── amplitude correctness ─────────────────────────────────────────────
+
+    def test_window_amplitude_equals_returned_amp_hyb_window(self, blend_setup):
+        """Amplitude of hybrid in the window must equal the returned amp_hyb_window."""
+        result = _run_blend(blend_setup)
+        hybrid = result[0][(2, 2)]
+        t1_i, t2_i = result[1], result[3]
+        amp_hyb_w = result[9][(2, 2)]
+        np.testing.assert_allclose(
+            compute_amplitude(hybrid[t1_i : t2_i + 1]), amp_hyb_w, rtol=1e-12
+        )
+
+    def test_mr_tail_amplitude_unaffected_by_phasor_shift(self, blend_setup):
+        """The constant phasor applied to the MR tail must not change its amplitude."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=True)
+        hybrid = result[0][(2, 2)]
+        t1_i, t2_i, t2_mr = result[1], result[3], result[4]
+        mr = blend_setup["mr_modes"][(2, 2)]
+        hybrid_tail = hybrid[t1_i + (t2_i - t1_i) + 1 :]
+        np.testing.assert_allclose(
+            compute_amplitude(hybrid_tail),
+            compute_amplitude(mr[t2_mr + 1 :]),
+            rtol=1e-12,
+        )
+
+    def test_window_amplitude_starts_at_inspiral_ends_at_mr(self, blend_setup):
+        """blend_series guarantees τ=0 at left → amp_hyb[0]=amp_insp[t1_i]
+        and τ=1 at right → amp_hyb[-1]=amp_mr[t2_mr]."""
+        result = _run_blend(blend_setup)
+        amp_hyb_w = result[9][(2, 2)]
+        amp_insp_w = result[8][(2, 2)]
+        amp_mr_w = result[10][(2, 2)]
+        assert amp_hyb_w[0] == pytest.approx(amp_insp_w[0], rel=1e-12)
+        assert amp_hyb_w[-1] == pytest.approx(amp_mr_w[-1], rel=1e-12)
+
+    # ── phase / frequency correctness ─────────────────────────────────────
+
+    def test_window_phase_is_integral_of_blended_frequency(self, blend_setup):
+        """Core test: phase in the blending window must equal the cumulative
+        trapezoid of frq_hyb_window plus the inspiral angle at window start.
+
+        This directly validates the numpy-cumsum trapezoid integration that
+        replaced scipy.integrate.cumulative_trapezoid.
+        """
+        result = _run_blend(blend_setup)
+        hybrid = result[0][(2, 2)]
+        t1_i, t2_i = result[1], result[3]
+        frq_hyb_w = result[6][(2, 2)]
+        dt = blend_setup["dt"]
+
+        expected = np.empty(len(frq_hyb_w))
+        expected[0] = -np.angle(blend_setup["inspiral_modes"][(2, 2)][t1_i])
+        expected[1:] = expected[0] + 2 * np.pi * np.cumsum(
+            0.5 * (frq_hyb_w[:-1] + frq_hyb_w[1:]) * dt
+        )
+        np.testing.assert_allclose(
+            compute_phase(hybrid[t1_i : t2_i + 1]), expected, rtol=1e-10
+        )
+
+    def test_phase_left_boundary_continuous(self, blend_setup):
+        """Phase of hybrid at t1_i must match inspiral phase at t1_i (no jump)."""
+        result = _run_blend(blend_setup)
+        hybrid = result[0][(2, 2)]
+        t1_i = result[1]
+        insp = blend_setup["inspiral_modes"][(2, 2)]
+        # The window phase is initialised from inspiral_angle_at_window_start
+        assert -np.angle(hybrid[t1_i]) == pytest.approx(
+            -np.angle(insp[t1_i]), abs=1e-12
+        )
+
+    def test_mr_tail_is_constant_phasor_shifted(self, blend_setup):
+        """The MR tail in the hybrid is the original MR tail times a constant
+        phasor — so the ratio hybrid_tail / mr_tail must be constant."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=True)
+        hybrid = result[0][(2, 2)]
+        t1_i, t2_i, t2_mr = result[1], result[3], result[4]
+        mr = blend_setup["mr_modes"][(2, 2)]
+        hybrid_tail = hybrid[t1_i + (t2_i - t1_i) + 1 :]
+        mr_tail = mr[t2_mr + 1 :]
+        if len(mr_tail) == 0:
+            pytest.skip("no MR tail samples")
+        ratio = hybrid_tail / mr_tail
+        np.testing.assert_allclose(np.angle(ratio), np.angle(ratio[0]), atol=1e-10)
+
+    def test_inspiral_head_is_constant_phasor_shifted_when_aligning_inspiral(
+        self, blend_setup
+    ):
+        """When the inspiral is phase-shifted to match MR, the head is multiplied
+        by a constant phasor — ratio hybrid_head / inspiral_head must be constant."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=False)
+        hybrid = result[0][(2, 2)]
+        t1_i = result[1]
+        insp = blend_setup["inspiral_modes"][(2, 2)]
+        if t1_i == 0:
+            pytest.skip("no inspiral head samples")
+        ratio = hybrid[:t1_i] / insp[:t1_i]
+        np.testing.assert_allclose(np.angle(ratio), np.angle(ratio[0]), atol=1e-10)
+
+    def test_blended_frequency_starts_at_inspiral_ends_at_mr(self, blend_setup):
+        """At τ=0 frq_hyb == frq_insp; at τ=1 frq_hyb == frq_mr."""
+        result = _run_blend(blend_setup)
+        frq_i_w = result[5][(2, 2)]
+        frq_h_w = result[6][(2, 2)]
+        frq_mr_w = result[7][(2, 2)]
+        assert frq_h_w[0] == pytest.approx(frq_i_w[0], rel=1e-12)
+        assert frq_h_w[-1] == pytest.approx(frq_mr_w[-1], rel=1e-12)
+
+    # ── both alignment directions ─────────────────────────────────────────
+
+    def test_align_inspiral_to_mr_produces_valid_output(self, blend_setup):
+        """blend_aligning_merger_to_inspiral=False must complete and return modes."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=False)
+        assert (2, 2) in result[0]
+        assert len(result[0][(2, 2)]) > 0
+
+    def test_window_phase_integral_correct_when_aligning_inspiral(self, blend_setup):
+        """Same phase-integral check for the align-inspiral-to-MR branch."""
+        result = _run_blend(blend_setup, blend_aligning_merger_to_inspiral=False)
+        hybrid = result[0][(2, 2)]
+        t1_i, t2_i = result[1], result[3]
+        frq_hyb_w = result[6][(2, 2)]
+        dt = blend_setup["dt"]
+
+        # In this branch, phase_h is offset so the window *ends* at mr_angle_at_window_end
+        mr_angle_end = -np.angle(blend_setup["mr_modes"][(2, 2)][result[4]])
+        raw_integral = (
+            2
+            * np.pi
+            * np.cumsum(
+                np.concatenate([[0], 0.5 * (frq_hyb_w[:-1] + frq_hyb_w[1:]) * dt])
+            )
+        )
+        offset = mr_angle_end - raw_integral[-1]
+        expected = raw_integral + offset
+        np.testing.assert_allclose(
+            compute_phase(hybrid[t1_i : t2_i + 1]), expected, rtol=1e-10
+        )


### PR DESCRIPTION
## Speed up waveform generation: Numba JIT + numpy over scipy

- JIT-compile compute_phase, compute_frequency, blend_series, and peak-
  frequency finding with @njit, eliminating intermediate allocations and
  Python loop overhead in the hot blending path
- Cache spherical harmonic evaluations via functools.lru_cache on _ylm
- Replace scipy.integrate.cumulative_trapezoid with an equivalent numpy
  cumsum in blend_modes and _get_transition_frequency_window, removing
  the scipy runtime dependency from the hot path
- Merge three sequential loops over modes in blend_modes into one,
  improving cache locality on the amplitude windows
- Add numba to setup.py dependencies; exclude build/ from flake8


## Add output-correctness tests for blend_modes

- 14 new tests in TestBlendModesOutput cover the numerical behaviour of
blend_modes: inspiral/MR head-tail preservation, amplitude and phase
continuity across the blending window, and that the window phase equals
the cumulative-trapezoid integral of the blended frequency — directly
validating the scipy→numpy cumsum replacement. Includes a synthetic
chirp fixture (blend_setup) and a _run_blend helper to keep tests
concise. Fixes an F841 flake8 warning (unused variable unpacking).
